### PR TITLE
Mayhem integration for lz4_flex

### DIFF
--- a/.github/workflows/mayhem.yaml
+++ b/.github/workflows/mayhem.yaml
@@ -1,0 +1,58 @@
+name: Mayhem
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    name: '${{ matrix.os }} shared=${{ matrix.shared }} ${{ matrix.build_type }}'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        shared: [false]
+        build_type: [Release]
+        include:
+          - os: ubuntu-latest
+            triplet: x64-linux
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Start analysis
+        uses: ForAllSecure/mcode-action@v1
+        with:
+          mayhem-token: ${{ secrets.MAYHEM_TOKEN }}
+          args: --image ${{ steps.meta.outputs.tags }}
+          sarif-output: sarif
+
+      - name: Upload SARIF file(s)
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: sarif

--- a/.github/workflows/mayhem.yaml
+++ b/.github/workflows/mayhem.yaml
@@ -8,6 +8,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   MAYHEMFILE: Mayhemfile
+  PROJECTNAME: lz4-flex-test # This is necessary due to the underscore in the default GitHub name
 
 jobs:
   build:
@@ -50,7 +51,7 @@ jobs:
         uses: ForAllSecure/mcode-action@v1
         with:
           mayhem-token: ${{ secrets.MAYHEM_TOKEN }}
-          args: --image ${{ steps.meta.outputs.tags }} --file ${{ env.MAYHEMFILE }} # Note that we manually specify the Mayhemfile to avoid underscore issues
+          args: --image ${{ steps.meta.outputs.tags }} --project ${{ env.PROJECTNAME }} # Note that we manually specify the Mayhemfile to avoid underscore issues
           sarif-output: sarif
 
       - name: Upload SARIF file(s)

--- a/.github/workflows/mayhem.yaml
+++ b/.github/workflows/mayhem.yaml
@@ -8,7 +8,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   MAYHEMFILE: Mayhemfile
-  PROJECTNAME: lz4-flex-test # This is necessary due to the underscore in the default GitHub name
+  PROJECTNAME: lz4-flex # This is necessary due to the underscore in the default GitHub name
 
 jobs:
   build:

--- a/.github/workflows/mayhem.yaml
+++ b/.github/workflows/mayhem.yaml
@@ -7,6 +7,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  MAYHEMFILE: Mayhemfile
 
 jobs:
   build:
@@ -49,7 +50,7 @@ jobs:
         uses: ForAllSecure/mcode-action@v1
         with:
           mayhem-token: ${{ secrets.MAYHEM_TOKEN }}
-          args: --image ${{ steps.meta.outputs.tags }}
+          args: --image ${{ steps.meta.outputs.tags }} --file ${{ env.MAYHEMFILE }} # Note that we manually specify the Mayhemfile to avoid underscore issues
           sarif-output: sarif
 
       - name: Upload SARIF file(s)

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,7 @@ RUN cargo install cargo-fuzz
 
 # BUILD INSTRUCTIONS
 WORKDIR /lz4_flex/fuzz
-RUN cargo +nightly fuzz build fuzz_roundtrip && \
-    cargo +nightly fuzz build fuzz_roundtrip_frame && \
-    cargo +nightly fuzz build fuzz_decomp_corrupt_block
+RUN cargo +nightly fuzz build fuzz_decomp_corrupt_block
 # Output binaries are placed in /lz4-flex/fuzz/target/x86_64-unknown-linux-gnu/release
 
 # Package Stage -- we package for a plain Ubuntu machine

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,14 @@
 FROM rustlang/rust:nightly as builder
 
 # Add source code to the build stage.
-ADD . /lz4-flex
-WORKDIR /lz4-flex
+ADD . /lz4_flex
+WORKDIR /lz4_flex
 
 RUN cargo install cargo-fuzz
 
 # BUILD INSTRUCTIONS
-WORKDIR /lz4-flex/fuzz
-RUN cargo +nightly fuzz build fuzz_roundtrip && \
-    cargo +nightly fuzz build fuzz_roundtrip_frame && \
-    cargo +nightly fuzz build fuzz_decomp_corrupt_block
+WORKDIR /lz4_flex/fuzz
+RUN cargo +nightly fuzz build fuzz_roundtrip
 # Output binaries are placed in /lz4-flex/fuzz/target/x86_64-unknown-linux-gnu/release
 
 # Package Stage -- we package for a plain Ubuntu machine
@@ -22,6 +20,4 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y gcc
 
 ## Copy the binary from the build stage to an Ubuntu docker image
-COPY --from=builder /lz4-flex/fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_roundtrip /
-COPY --from=builder /lz4-flex/fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_roundtrip_frame /
-COPY --from=builder /lz4-flex/fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_decomp_corrupt_block /
+COPY --from=builder /lz4_flex/fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_roundtrip /

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,5 @@ RUN cargo +nightly fuzz build fuzz_roundtrip && \
 # Package Stage -- we package for a plain Ubuntu machine
 FROM --platform=linux/amd64 ubuntu:20.04
 
-## Install build dependencies.
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y gcc
-
 ## Copy the binary from the build stage to an Ubuntu docker image
-COPY --from=builder /lz4_flex/fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_decomp_corrupt_block /
+COPY --from=builder /lz4_flex/fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_decomp_corrupt_block /fuzz-decomp-corrupt-block

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@ RUN cargo install cargo-fuzz
 
 # BUILD INSTRUCTIONS
 WORKDIR /lz4_flex/fuzz
-RUN cargo +nightly fuzz build fuzz_roundtrip
+RUN cargo +nightly fuzz build fuzz_roundtrip && \
+    cargo +nightly fuzz build fuzz_roundtrip_frame && \
+    cargo +nightly fuzz build fuzz_decomp_corrupt_block
 # Output binaries are placed in /lz4-flex/fuzz/target/x86_64-unknown-linux-gnu/release
 
 # Package Stage -- we package for a plain Ubuntu machine
@@ -20,4 +22,4 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y gcc
 
 ## Copy the binary from the build stage to an Ubuntu docker image
-COPY --from=builder /lz4_flex/fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_roundtrip /
+COPY --from=builder /lz4_flex/fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_decomp_corrupt_block /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Use Rust to build
+FROM rustlang/rust:nightly as builder
+
+# Add source code to the build stage.
+ADD . /lz4-flex
+WORKDIR /lz4-flex
+
+RUN cargo install cargo-fuzz
+
+# BUILD INSTRUCTIONS
+WORKDIR /lz4-flex/fuzz
+RUN cargo +nightly fuzz build fuzz_roundtrip && \
+    cargo +nightly fuzz build fuzz_roundtrip_frame && \
+    cargo +nightly fuzz build fuzz_decomp_corrupt_block
+# Output binaries are placed in /lz4-flex/fuzz/target/x86_64-unknown-linux-gnu/release
+
+# Package Stage -- we package for a plain Ubuntu machine
+FROM --platform=linux/amd64 ubuntu:20.04
+
+## Install build dependencies.
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y gcc
+
+## Copy the binary from the build stage to an Ubuntu docker image
+COPY --from=builder /lz4-flex/fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_roundtrip /
+COPY --from=builder /lz4-flex/fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_roundtrip_frame /
+COPY --from=builder /lz4-flex/fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_decomp_corrupt_block /

--- a/Mayhemfile
+++ b/Mayhemfile
@@ -3,3 +3,4 @@ target: fuzz_decomp_corrupt_block
 
 cmds:
   - cmd: /fuzz_decomp_corrupt_block
+    max_length: 100000

--- a/Mayhemfile
+++ b/Mayhemfile
@@ -1,6 +1,6 @@
 project: lz4-flex
 target: fuzz-decomp-corrupt-block
-image: ghcr.io/aaronjsteele/lz4_flex:latest
+image: ghcr.io/aaronjsteele/lz4-flex:latest
 
 cmds:
   - cmd: /fuzz-decomp-corrupt-block

--- a/Mayhemfile
+++ b/Mayhemfile
@@ -1,4 +1,4 @@
-project: lz4-flex-testproject
+project: lz4-flex
 target: fuzz-decomp-corrupt-block
 image: ghcr.io/aaronjsteele/lz4-flex:latest
 

--- a/Mayhemfile
+++ b/Mayhemfile
@@ -1,4 +1,4 @@
-project: lz4-flex
+project: lz4-flex-testproject
 target: fuzz-decomp-corrupt-block
 image: ghcr.io/aaronjsteele/lz4-flex:latest
 

--- a/Mayhemfile
+++ b/Mayhemfile
@@ -1,6 +1,7 @@
-project: lz4_flex
-target: fuzz_decomp_corrupt_block
+project: lz4-flex
+target: fuzz-decomp-corrupt-block
+image: ghcr.io/aaronjsteele/lz4_flex:latest
 
 cmds:
-  - cmd: /fuzz_decomp_corrupt_block
+  - cmd: /fuzz-decomp-corrupt-block
     max_length: 100000

--- a/Mayhemfile
+++ b/Mayhemfile
@@ -1,5 +1,5 @@
 project: lz4_flex
-target: fuzz_roundtrip
+target: fuzz_decomp_corrupt_block
 
 cmds:
-  - cmd: /fuzz_roundtrip
+  - cmd: /fuzz_decomp_corrupt_block

--- a/Mayhemfile
+++ b/Mayhemfile
@@ -1,6 +1,5 @@
 project: lz4-flex
 target: fuzz-decomp-corrupt-block
-image: ghcr.io/aaronjsteele/lz4-flex:latest
 
 cmds:
   - cmd: /fuzz-decomp-corrupt-block

--- a/Mayhemfile
+++ b/Mayhemfile
@@ -1,0 +1,5 @@
+project: lz4_flex
+target: fuzz_roundtrip
+
+cmds:
+  - cmd: /fuzz_roundtrip


### PR DESCRIPTION
Implemented an initial integration of Mayhem with the `lz4_flex` project. This includes a Dockerfile, Mayhemfile, and GitHub action to run Mayhem. Only implementation of one of the targets (`fuzz_decomp_corrupt_block`) was done, though adding the other targets would be very straightforward. The Mayhemfile changes the `max_length` parameter to allow longer test cases; the fuzzer fails otherwise (there are no test cases of a size smaller than the default `max_length` value). Similarly, the project name is explicitly specified in the GitHub action, as Mayhem does not like project names with underscores.